### PR TITLE
Remove the early return when generating sitemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,9 @@ module.exports = (nextConfig) => ({
       }
 
       generator(sitemap);
-
-      return config;
     }
 
     if (typeof nextConfig.webpack === 'function') {
-
       return nextConfig.webpack(config, options)
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
avoid breaking getting config by webpack function

## Description
<!--- Describe your changes in detail -->
The webpack config is returned too early when it is `isServer`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Nope.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Get custom config with input webpack function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working in my local machine and deployed to Vercel successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
